### PR TITLE
chore: normalize README maintenance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ docker run \
 
 ## Maintenance
 
-See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ docker run \
     -p 8080:8080 \
     dockette/adminerevo
 ```
+
+## Maintenance
+
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package.


### PR DESCRIPTION
## What changed
- removed `Maintainers` sections where present
- normalized maintenance docs to this exact section content:
  - `## Maintenance`
  - `See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.`

## Why
- keep contribution and maintenance guidance consistent in all selected Dockette image READMEs