### PR TITLE
chore: modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 8 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build"


### PR DESCRIPTION
## Summary
- update deprecated GitHub Action majors in workflow definitions (including actions/cache to v4)
- modernize Docker action majors to supported versions
- add explicit least-privilege workflow permissions (contents: read)

## Why
- prevent failures from deprecated action versions and keep CI workflows supportable
- make workflow token permissions explicit and minimal while preserving behavior