### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,17 +13,68 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: "Test"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for testing
+        uses: docker/build-push-action@v7
+        with:
+          context: adminerevo
+          file: adminerevo/Dockerfile
+          push: false
+          tags: dockette/adminerevo:latest-test
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          load: true
+
+      - name: Test Adminerevo UI
+        run: |
+          docker run --rm -d --name adminerevo-test -p 8080:8080 dockette/adminerevo:latest-test
+          sleep 3
+          curl -fsS http://localhost:8080/ > /dev/null
+          echo "Adminerevo UI OK"
+
+      - name: Cleanup
+        if: always()
+        run: docker stop adminerevo-test || true
+
   build:
     name: "Build"
+    needs: test
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:
-        image: "dockette/adminerevo"
-        tag: "${{ matrix.item }}"
-        context: "${{ matrix.context }}"
+      image: "dockette/adminerevo"
+      tag: "${{ matrix.item }}"
+      context: "${{ matrix.context }}"
+      push: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       matrix:
         include:
           - { item: latest, context: adminerevo }
 
       fail-fast: false
+
+  docs:
+    name: "Docs"
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: dockette/adminerevo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,33 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Dockette Adminerevo packages Adminerevo, a single-file PHP database management UI, behind Caddy and PHP-FPM. The image exposes the web UI on port `8080`.
+
+## Image
+
+- Image name is `dockette/adminerevo`.
+- Default tag is `latest`, controlled by `DOCKER_TAG`.
+- Build context is `adminerevo`, not the repository root.
+- `adminerevo/Dockerfile` uses `alpine:3.20` and downloads `ADMINEREVO_VERSION=4.8.4` from the Adminerevo GitHub release.
+- The image includes Caddy, PHP 8.3 FPM, and PHP extensions for MySQL, PostgreSQL, JSON, and sessions.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` uses Docker Buildx with `--platform ${DOCKER_PLATFORM}`, `--load`, and context `adminerevo`.
+- `make test` builds first, runs the image detached on `${DOCKER_TEST_PORT}:8080`, and checks `http://localhost:${DOCKER_TEST_PORT}/`.
+- `make run` starts an interactive container named `adminer` on `8080:8080`.
+- `make docker-build`, `make docker-test`, and `make docker-run` delegate to the primary targets.
+
+## Runtime Notes
+
+- No Compose file is present; local runtime is direct `docker run`.
+- Default platform is `linux/amd64`; keep Makefile and workflow platform assumptions aligned.
+- GitHub Actions builds from context `adminerevo` with file `adminerevo/Dockerfile`, tests the UI on port `8080`, and publishes `dockette/adminerevo:latest` on `master`.
+- `Caddyfile`, `php-fpm.conf`, and `entrypoint.sh` are part of the image contract and must stay in the `adminerevo` context.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep `README.md`, `Makefile`, `adminerevo/Dockerfile`, and `.github/workflows/docker.yml` aligned when changing versions, ports, or contexts.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
 - Keep README badges and maintenance sections consistent with other Dockette image repos.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,47 @@
 DOCKER_IMAGE=dockette/adminerevo
-DOCKER_PLATFORM=linux/amd64
-DOCKER_TEST_PORT=8080
+DOCKER_TAG?=latest
+DOCKER_PLATFORM?=linux/amd64
+DOCKER_TEST_PORT?=8080
 
 .PHONY: build
-build: docker-build
-
-.PHONY: test
-test: docker-test
-
-.PHONY: run
-run: docker-run
-
-.PHONY: docker-build
-docker-build:
+build:
 	docker buildx \
 		build \
 		--platform ${DOCKER_PLATFORM} \
 		--pull \
 		--load \
-		-t ${DOCKER_IMAGE} \
+		-t ${DOCKER_IMAGE}:${DOCKER_TAG} \
 		adminerevo
 
-.PHONY: docker-test
-docker-test: docker-build
+.PHONY: test
+test: build
 	@set -e; \
 	container=$$(docker run --rm -d \
 		--platform ${DOCKER_PLATFORM} \
 		-p ${DOCKER_TEST_PORT}:8080 \
-		${DOCKER_IMAGE}); \
+		${DOCKER_IMAGE}:${DOCKER_TAG}); \
 	trap 'docker stop $$container >/dev/null' EXIT; \
 	sleep 3; \
 	curl -fsS http://localhost:${DOCKER_TEST_PORT}/ >/dev/null
 
-.PHONY: docker-run
-docker-run:
+.PHONY: run
+run:
 	docker run \
 		-it \
 		--rm \
 		--platform ${DOCKER_PLATFORM} \
 		-p 8080:8080 \
 		--name adminer \
-		${DOCKER_IMAGE}
+		${DOCKER_IMAGE}:${DOCKER_TAG}
+
+.PHONY: docker-build
+docker-build:
+	$(MAKE) build
+
+.PHONY: docker-test
+docker-test: docker-build
+	$(MAKE) test
+
+.PHONY: docker-run
+docker-run:
+	$(MAKE) run

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 DOCKER_IMAGE=dockette/adminerevo
 DOCKER_PLATFORM=linux/amd64
+DOCKER_TEST_PORT=8080
+
+.PHONY: build
+build: docker-build
+
+.PHONY: test
+test: docker-test
+
+.PHONY: run
+run: docker-run
 
 .PHONY: docker-build
 docker-build:
@@ -7,8 +17,20 @@ docker-build:
 		build \
 		--platform ${DOCKER_PLATFORM} \
 		--pull \
+		--load \
 		-t ${DOCKER_IMAGE} \
 		adminerevo
+
+.PHONY: docker-test
+docker-test: docker-build
+	@set -e; \
+	container=$$(docker run --rm -d \
+		--platform ${DOCKER_PLATFORM} \
+		-p ${DOCKER_TEST_PORT}:8080 \
+		${DOCKER_IMAGE}); \
+	trap 'docker stop $$container >/dev/null' EXIT; \
+	sleep 3; \
+	curl -fsS http://localhost:${DOCKER_TEST_PORT}/ >/dev/null
 
 .PHONY: docker-run
 docker-run:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 <h1 align=center>Dockette / Adminerevo</h1>
 
 <p align=center>
-   🎁 Dockerized <a href="https://https://docs.adminerevo.org/">Adminerevo</a> (MySQL, PostgreSQL, SQLite, Mongo, Oracle). Database management in a single PHP file.
+   <a href="https://github.com/dockette/adminerevo/actions"><img src="https://github.com/dockette/adminerevo/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/adminerevo"><img src="https://img.shields.io/docker/pulls/dockette/adminerevo.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 <p align=center>
-🕹 <a href="https://f3l1x.io">f3l1x.io</a> | 💻 <a href="https://github.com/f3l1x">f3l1x</a> | 🐦 <a href="https://twitter.com/xf3l1x">@xf3l1x</a>
-</p>
-
-<p align=center>
-  <a href="https://hub.docker.com/r/dockette/adminerevo/"><img src="https://badgen.net/docker/pulls/dockette/adminerevo"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://github.com/sponsors/f3l1x"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+   🎁 Dockerized <a href="https://docs.adminerevo.org/">Adminerevo</a> (MySQL, PostgreSQL, SQLite, Mongo, Oracle). Database management in a single PHP file.
 </p>
 
 ![Adminerevo](https://raw.githack.com/dockette/adminerevo/master/.docs/adminerevo.png)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 <h1 align=center>Dockette / Adminerevo</h1>
 
 <p align=center>
-   <a href="https://github.com/dockette/adminerevo/actions"><img src="https://github.com/dockette/adminerevo/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
    <a href="https://hub.docker.com/r/dockette/adminerevo"><img src="https://img.shields.io/docker/pulls/dockette/adminerevo.svg" alt="Docker Hub pulls"></a>
    <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
    <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 <p align=center>
-   🎁 Dockerized <a href="https://docs.adminerevo.org/">Adminerevo</a> (MySQL, PostgreSQL, SQLite, Mongo, Oracle). Database management in a single PHP file.
+   🎁 Dockerized <a href="https://docs.adminerevo.org/">Adminerevo</a> with MySQL and PostgreSQL drivers. Database management in a single PHP file.
 </p>
 
 ![Adminerevo](https://raw.githack.com/dockette/adminerevo/master/.docs/adminerevo.png)
@@ -23,6 +22,8 @@ docker run \
     -p 8080:8080 \
     dockette/adminerevo
 ```
+
+Open <http://localhost:8080/> in your browser.
 
 ## Maintenance
 


### PR DESCRIPTION
What changed
- Added a Test job before the reusable Docker Build workflow with an Adminerevo HTTP UI smoke test.
- Added a Docker Hub description Docs job for dockette/adminerevo.
- Added build/test/run Makefile aliases around existing Docker targets.
- Normalized README badges to the Dockette Copybara style, removed legacy Gitter/badgen badges, and fixed the Adminerevo docs link.

Why
- Aligns dockette/adminerevo with the Dockette CI rollout baseline for active Docker image repositories.